### PR TITLE
[video_remuxer] 0.0.13

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/ffmpeg"]
 	path = lib/ffmpeg
-	url = git@github.com:Josh5/unmanic.plugin.helpers.ffmpeg.git
+	url = https://github.com/Josh5/unmanic.plugin.helpers.ffmpeg.git

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 
+**<span style="color:#56adda">0.0.13</span>**
+- update ffmpeg helper to latest to avoid error when probe result contains the legitimate string "error"
+
 **<span style="color:#56adda">0.0.12</span>**
 - Plugin should throw an exception when FFmpeg is not correctly installed
 - Prevent HEVC codec support on AVI

--- a/info.json
+++ b/info.json
@@ -15,5 +15,5 @@
         "on_worker_process": 3
     },
     "tags": "video,ffmpeg",
-    "version": "0.0.12"
+    "version": "0.0.13"
 }


### PR DESCRIPTION
Updates ffmpeg helper library to most recent in order to avoid an error when probe results legitimately container the string "error".